### PR TITLE
Adopt Architecture Decision Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# roadmap
-Tracking the progress and status of the development roadmap
+# Bonsai ecosystem roadmap
+
+Architecture Decision Records for the Bonsai ecosystem: the durable record of why significant, cross-cutting decisions were made across the language, the standard library, packaging, infrastructure, and the wider community.
+
+An ADR here records a decision and the reasoning behind it, and is distinct from a proposal. A proposal is a forward-looking specification to build something and lives in the repository it affects, for example `bonsai-rx/bonsai`. An ADR instead captures why a strategic ecosystem decision was taken, whether that means building, replacing, or removing, and may motivate or supersede several proposals across repositories.
+
+Architecture is read broadly, spanning software, community, and process. A record can sit un-decided for months while its assessments are worked, and status tracks how far it has progressed. The process itself is defined in [ADR-0001](decisions/0001-adopt-architecture-decision-records/); the record template lives in [TEMPLATE](TEMPLATE/), and the shared decision criteria in [criteria.md](criteria.md).
+
+## Records
+
+| ID | Title | Area | Status | Owners |
+|----|-------|------|--------|--------|
+| [ADR-0001](decisions/0001-adopt-architecture-decision-records/) | Adopt Architecture Decision Records for the Bonsai ecosystem | Ecosystem | Approved | glopesdev |

--- a/TEMPLATE/README.md
+++ b/TEMPLATE/README.md
@@ -1,0 +1,81 @@
+---
+id: ADR-NNNN
+title: "{concise decision title}"
+status: Assessment          # Assessment | Review | Approved | Rejected | Suspended | Superseded
+area: [Ecosystem]           # Language | Standard Library | Packaging | Infrastructure | Ecosystem
+owners: []
+related: []                 # [ADR-000N], with the relation explained in prose
+discussions:                # links to issues, discussions, or meeting notes that inform the decision
+---
+
+<!--
+To author a record, copy this directory to decisions/NNNN-short-slug/, fill in the front matter and
+the sections below, and add a row to the register in the repository README. The Trade-off Matrix and
+Assessments sections are optional; omit them for a decision made by reasoning rather than
+measurement, and carry the reasoning in Decision. The full process is defined in ADR-0001.
+-->
+
+# ADR-NNNN: {Title}
+
+## Summary
+
+<!-- The decision to be made and, once decided, the outcome. One paragraph, written to stand alone
+for a reader arriving without prior context. -->
+
+## Context
+
+<!-- What forces this decision now: background, current state, and why the status quo is
+insufficient. State what is out of scope, pointing to a related record where relevant. -->
+
+## Criteria
+
+<!-- The criteria that decide this, drawn from criteria.md. List only the ones that materially
+apply, and note any decision-specific weighting. These become the columns of the decision matrix. -->
+
+## Options
+
+<!-- One subsection per candidate option, described neutrally with its pros and cons. Keep option
+labels stable so the matrix can refer to them. -->
+
+### Option A: {name}
+
+### Option B: {name}
+
+## Trade-off Matrix
+
+<!-- Options as rows, criteria as columns. Each cell is a rating that cites a finding, or TBD with
+a reference to the assessment that will resolve it, e.g. TBD -> ADR-NNNN-A0n. A value of must-pass
+means an option is eliminated if it fails the cell. No cell is filled by guesswork. -->
+
+| Criterion | Option A | Option B |
+|-----------|----------|----------|
+|           |          |          |
+
+## Assessments
+
+<!-- The open questions that resolve the matrix, each with an exit criterion and a file under
+assessments/. A disqualifying assessment is a must-pass check whose failure eliminates an option,
+worked first because it prunes the option space cheapest. A scoring assessment is a comparative
+check that fills a cell to weigh the survivors. -->
+
+| ID | Question | Method | Kind | Status | Exit Criterion |
+|----|----------|--------|------|--------|----------------|
+|    |          |        |      |        |                |
+
+## Decision
+
+<!-- Filled when the status reaches Approved or Rejected. The chosen option and the reasoning,
+referring to the decisive cells of the matrix, stating what evidence decided it. -->
+
+## Consequences
+
+<!-- What the decision commits us to, positive and negative, including the backward compatibility
+and migration path for existing workflows and packages, and any follow-up records this generates. -->
+
+## References
+
+<!-- Prior art, external canonical sources, and links to source via full commit-hash URLs. -->
+
+## Design Meetings
+
+<!-- Links to the discussions and meetings where this record was worked. -->

--- a/TEMPLATE/assessment.md
+++ b/TEMPLATE/assessment.md
@@ -1,0 +1,31 @@
+---
+id: ADR-NNNN-A01
+decision: ADR-NNNN
+method: code-scan           # code-scan | desk-research | benchmark | prototype
+kind: scoring               # scoring | disqualifying
+status: Open                # Open | In Progress | Done | Blocked
+owner:
+exit-criterion: "{the result that closes this}"
+---
+
+<!--
+One assessment: a single question that resolves one or more matrix cells. Copy to
+assessments/ADR-NNNN-A0n.md. A disqualifying assessment is a must-pass check whose failure removes
+an option; a scoring assessment is a comparative measurement that fills a cell.
+-->
+
+# {Assessment Title}
+
+## Question
+
+## Method
+
+## Artifacts
+
+<!-- Links into ../findings/ for data, benchmark output, or prototype notes. -->
+
+## Finding
+
+## Implications
+
+<!-- Which matrix cells this fills or clears, and which options it affects. -->

--- a/criteria.md
+++ b/criteria.md
@@ -1,0 +1,37 @@
+# Decision Criteria
+
+Shared criteria for weighing options in an Architecture Decision Record. A record cites the subset that applies and notes any decision-specific weighting. The columns in a decision trade-off matrix are drawn from this list.
+
+Scores are qualitative unless a record defines a measured rubric.
+
+## Ecosystem Continuity Risk
+
+Risk that a decision breaks existing workflows or published packages, or splits the community into incompatible camps. Lower is better. This is often the dominant criterion, given a large body of workflows and packages that cannot be recompiled or republished.
+
+## Maintenance Burden
+
+Ongoing effort to keep the result working over time: tracking upstream changes, native runtime updates, API drift, and user support. Lower is better. Estimated as a proportion of having a full-time person dedicated to the outcome.
+
+## Performance
+
+Runtime cost against the current baseline for representative workflows: per-call overhead, allocation, and memory footprint. Measured as a ratio to the baseline where a benchmark exists.
+
+## Feature Velocity
+
+How quickly new upstream capability becomes available to workflow authors after it appears upstream. Higher is better.
+
+## Control
+
+The degree to which the ecosystem controls the public surface, semantics, and release timing of the result, rather than depending on an external party. Higher is better, weighed against maintenance burden, since more control usually costs more effort.
+
+## Effort
+
+One-time cost to reach the outcome, against the available budget. Estimated in months assuming a full-time person is dedicated to the outcome.
+
+## Reversibility
+
+How cheaply the decision can be revised later. A reversible decision is a two-way door; a one-way door that is expensive to undo carries more risk and deserves more evidence before it is taken. Higher is better.
+
+## Community Trust
+
+Effect on user and contributor confidence and continuity, including how a transition is communicated and how conservative users are affected. Higher is better.

--- a/decisions/0001-adopt-architecture-decision-records/README.md
+++ b/decisions/0001-adopt-architecture-decision-records/README.md
@@ -1,0 +1,74 @@
+---
+id: ADR-0001
+title: Adopt Architecture Decision Records for the Bonsai ecosystem
+status: Approved
+area: [Ecosystem]
+owners: [glopesdev]
+related: []
+discussions:
+---
+
+# ADR-0001: Adopt Architecture Decision Records for the Bonsai ecosystem
+
+## Summary
+
+The Bonsai v3 roadmap brings a series of significant, cross-cutting decisions that span more than one repository and, in some cases, the whole community. We will adopt Architecture Decision Records (ADR), kept in this repository, as the durable record of why each such decision was made. This document defines the record format, the status lifecycle, and how records relate to the forward-looking proposals that already live in individual repositories.
+
+## Context
+
+Decisions on the roadmap are high-stakes and often irreversible in practice. They reach across the language, the standard library, packaging, infrastructure, and the community, and a single decision can motivate work in several repositories at once. The existing proposal process in `bonsai-rx/bonsai`, with its specification-proposal issue template, is scoped to language features and is forward-looking by design. It captures what to build specifically in the language, compiler, and editor, but not the reasoning behind a cross-cutting ecosystem direction, and it has no natural place for a decision whose outcome is to remove or replace something rather than add to it.
+
+What we are missing is a community record of the reasoning behind community strategic decisions: the options considered, the criteria applied, the evidence gathered, and why one path was chosen over the others. Without it, this kind of cross-cutting reasoning stays scattered across issues and discussions with a narrower scope, and which may themselves be renumbered, moved, or deleted over time.
+
+## Criteria
+
+- Familiarity. A new contributor should recognize the format without a glossary.
+- Breadth and neutrality. The format must fit a decision to build, replace, or remove, across software, community, and process.
+- Low ceremony. Fields and status values should be self-explanatory and cheap to keep current.
+- Self-containment. Each record should stand alone for a reader arriving without prior context.
+- Separation from proposals. The decision layer should be distinct from the forward-looking proposal layer.
+
+## Options
+
+### Option A: Architecture Decision Records
+
+Adopt the established ADR format, introduced by Michael Nygard, kept in this repository. Records carry a decision, the options, and the reasoning. The term is widely recognized, directionally neutral, and fits decisions across the whole ecosystem.
+
+### Option B: An Enhancement-Proposal Series
+
+Adopt a numbered enhancement-proposal series in the style of Python PEPs, Rust RFCs, or Kubernetes KEPs. This is well understood, but enhancement presupposes an additive, monotonic change. A decision whose outcome is to drop or replace something does not fit the frame cleanly, and the series would overlap with the existing language-proposal process rather than sit above it.
+
+### Option C: Ad-hoc Issues and Discussions
+
+Keep recording decisions in issues and discussion threads, as today. This has the lowest setup cost, but the reasoning stays scattered and tied to tracker state that renumbers and moves, and the pressure to keep each issue self-contained to the scope of its repository can often hide the cross-cutting concern itself, which is the main problem we want to solve.
+
+## Decision
+
+Adopt Option A. Architecture Decision Records are kept in this repository, one per directory under `decisions/NNNN-short-slug/`, following the template in `TEMPLATE/` and the shared criteria in `criteria.md`.
+
+Naming conventions and glossary:
+
+- Identifier. `ADR-NNNN`, held in the `id` field and mirrored by the directory number. The generic field name keeps the series easy to rename later without rewriting records.
+- Expansion. Architecture Decision Record, using Architecture as a noun naming the subject matter. Architecture is read broadly, spanning software, community, and process.
+- Status. Assessment, Review, Approved, Rejected, Suspended, or Superseded. A record starts in Assessment the moment it is opened. It moves to Review once the evidence is gathered, then to Approved or Rejected. Suspended means the decision is on hold for the moment but may return. Superseded means the decision was made but later replaced.
+- Area. One or more of Language, Standard Library, Packaging, Infrastructure, and Ecosystem, where Ecosystem covers cross-cutting community and process matters not tied to a single code area.
+- Relations. A `related` list which names connected records. The nature of the relation, including supersession, is stated in prose rather than in separate machine-readable fields.
+- Proposal. A proposal is a forward-looking request to build something and lives in the repository it affects.
+- Record. A record captures why a direction was chosen and may motivate or supersede several proposals across repositories.
+
+A record may sit in Assessment or Review for months while its assessments are worked. This differs from the classic form, where a record is written at the moment of decision. The status field carries how far the decision has progressed.
+
+The template for a decision record also includes a trade-off matrix, options weighed against criteria, and an assessment backlog that resolves the unknown cells. A disqualifying assessment is a must-pass check whose failure removes an option. A scoring assessment is a comparative measurement that fills a cell. Both the matrix and the assessments are optional, and are omitted for a decision made by reasoning rather than measurement, as in this record.
+
+## Consequences
+
+Cross-cutting decisions and their reasoning are centralized in this repository, versioned alongside the rest of the roadmap and separate from the per-repository proposal process. Revising a decision is done by superseding a record rather than editing it, so the earlier reasoning stays in history.
+
+The process adds a repository and a convention to maintain, and it depends on contributors opening a record while a decision is still open rather than after it has been settled. The template and criteria are separate files, so editing them does not require superseding this record.
+
+## References
+
+- Michael Nygard, Documenting Architecture Decisions, the original ADR formulation, at https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+- MADR, the Markdown Architecture Decision Records project, at https://adr.github.io and https://github.com/adr/madr
+- Python PEP 1 at https://peps.python.org/pep-0001/, the Rust RFCs at https://github.com/rust-lang/rfcs, and Kubernetes KEPs at https://github.com/kubernetes/enhancements, as precedents for numbered decision and proposal records
+- The specification-proposal template in `bonsai-rx/bonsai`, introduced in [bonsai-rx/bonsai#2586](https://github.com/bonsai-rx/bonsai/pull/2586), which this format complements at the ecosystem level


### PR DESCRIPTION
Sets up `bonsai-rx/roadmap` as a home for Architecture Decision Records, the durable record of why cross-cutting decisions are made across the Bonsai ecosystem, spanning the language, standard library, packaging, infrastructure, and community. An ADR captures the reasoning behind a strategic direction and is distinct from the forward-looking proposals that live in individual repositories.

This adds the process and its first record:

- A register in the repository README.
- The record template and the assessment template under `TEMPLATE`.
- Shared decision criteria in `criteria.md`.
- ADR-0001, which adopts the process and defines the record format, the status lifecycle, and how records relate to proposals. It follows the [original ADR format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions) introduced by Michael Nygard, with the sections Context, Decision, and Consequences, extended with a criteria list, an options comparison, and an optional trade-off matrix and assessment backlog for decisions that need evidence.