### PR TITLE
Refine the record schema and register

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ An ADR here records a decision and the reasoning behind it, and is distinct from
 
 Architecture is read broadly, spanning software, community, and process. A record can sit un-decided for months while its assessments are worked, and status tracks how far it has progressed. The process itself is defined in [ADR-0001](decisions/0001-adopt-architecture-decision-records/); the record template lives in [TEMPLATE](TEMPLATE/), and the shared decision criteria in [criteria.md](criteria.md).
 
+## Working with Records
+
+Records are living documents, so a record is created early, while still in `Assessment`. This keeps `main` showing which decisions are open and how far each has progressed.
+
+A pull request is scoped to one coherent increment rather than a whole decision: creating a record with its framing and open assessments, recording a completed assessment or a status change, or creating a sub-record that a parent decision spun off. Each merges to `main` on its own, and later work branches again from the updated `main` rather than stacking pull requests on one another.
+
 ## Records
 
-| ID | Title | Area | Status | Owners |
-|----|-------|------|--------|--------|
-| [ADR-0001](decisions/0001-adopt-architecture-decision-records/) | Adopt Architecture Decision Records for the Bonsai ecosystem | Ecosystem | Approved | glopesdev |
+| ID | Title | Area | Status |
+|----|-------|------|--------|
+| [ADR-0001](decisions/0001-adopt-architecture-decision-records/) | Adopt Architecture Decision Records for the Bonsai ecosystem | Ecosystem | Approved |

--- a/TEMPLATE/README.md
+++ b/TEMPLATE/README.md
@@ -3,7 +3,7 @@ id: ADR-NNNN
 title: "{concise decision title}"
 status: Assessment          # Assessment | Review | Approved | Rejected | Suspended | Superseded
 area: [Ecosystem]           # Language | Standard Library | Packaging | Infrastructure | Ecosystem
-owners: []
+authors: []
 related: []                 # [ADR-000N], with the relation explained in prose
 discussions:                # links to issues, discussions, or meeting notes that inform the decision
 ---

--- a/decisions/0001-adopt-architecture-decision-records/README.md
+++ b/decisions/0001-adopt-architecture-decision-records/README.md
@@ -3,7 +3,7 @@ id: ADR-0001
 title: Adopt Architecture Decision Records for the Bonsai ecosystem
 status: Approved
 area: [Ecosystem]
-owners: [glopesdev]
+authors: [glopesdev]
 related: []
 discussions:
 ---


### PR DESCRIPTION
Schema and register cleanup ahead of opening new records.

- Rename the record frontmatter field `owners` to `authors`.
- Drop the author column from the register, so it lists only ID, title, area, and status.
- Add a Working with Records section to the README describing the one-increment-per-PR workflow.
