### PR TITLE
Open ADR-0003 and ADR-0004 on the editor future

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ A pull request is scoped to one coherent increment rather than a whole decision:
 |----|-------|------|--------|
 | [ADR-0001](decisions/0001-adopt-architecture-decision-records/) | Adopt Architecture Decision Records for the Bonsai ecosystem | Ecosystem | Approved |
 | [ADR-0002](decisions/0002-modernize-net-stack/) | Modernizing the Bonsai .NET stack | Ecosystem, Infrastructure, Packaging | Assessment |
+| [ADR-0003](decisions/0003-editor-operation-model/) | A UI-agnostic operation model for the Bonsai editor | Ecosystem, Infrastructure | Assessment |
+| [ADR-0004](decisions/0004-cross-platform-editor/) | A cross-platform presentation stack for the Bonsai editor | Ecosystem, Infrastructure | Assessment |

--- a/decisions/0002-modernize-net-stack/README.md
+++ b/decisions/0002-modernize-net-stack/README.md
@@ -4,7 +4,7 @@ title: Modernizing the Bonsai .NET stack
 status: Assessment
 area: [Ecosystem, Infrastructure, Packaging]
 authors: [glopesdev]
-related: []
+related: [ADR-0003, ADR-0004]
 discussions:
 ---
 
@@ -44,7 +44,7 @@ All criteria in [criteria.md](../../criteria.md) bear on the modernization, but 
 
 The modernization resolves into a set of decisions, several of which are being scoped as their own records that reference this umbrella:
 
-- The cross-platform editor architecture: decoupling the editor operation model from WinForms into a UI-agnostic editing core, then choosing a presentation stack over it. To be created as its own record, which will unlock a headless editing surface for automation and agents.
+- The cross-platform editor architecture: decoupling the editor operation model from WinForms into a presentation-independent library, then choosing a presentation stack over it. Recorded as ADR-0003, the UI-agnostic operation model, which unlocks a headless editing surface for automation and agents, and ADR-0004, the presentation stack.
 - Adopting modern Rx.NET across target frameworks: containing the Rx strong-name break at the target-framework boundary, and recommending a version for package developers who multi-target. To be created as its own record.
 - The future of `OpenCV.Net`, the primary image-processing dependency, to be created as its own record.
 - A stable abstraction for Bonsai 3D graphics and audio: the future of the `OpenTK`-dependent graphics and audio stack, and how to introduce an owned abstraction where none exists today. To be created as its own record.

--- a/decisions/0003-editor-operation-model/README.md
+++ b/decisions/0003-editor-operation-model/README.md
@@ -1,0 +1,59 @@
+---
+id: ADR-0003
+title: A UI-agnostic operation model for the Bonsai editor
+status: Assessment
+area: [Ecosystem, Infrastructure]
+authors: [glopesdev]
+related: [ADR-0002, ADR-0004]
+discussions:
+---
+
+# ADR-0003: A UI-agnostic operation model for the Bonsai editor
+
+## Summary
+
+The Bonsai editor already runs on .NET 8, but its operation model, the logic that constructs and manipulates a workflow, is interleaved with WinForms, so it cannot be reused under a different UI. This record commits to decoupling that operation model from WinForms into a presentation-independent library with a public API expressed in terms of workflow editing operations. This record can reach Approved ahead of the cross-platform presentation stack in ADR-0004, since the decoupled operation model can be released without breaking anything and is independent of that decision. The same decoupling also unlocks a headless editing surface for automation and agents. Getting its two extensibility abstractions right, the property model and the type visualizer model, is a precondition for the full cross-platform editor, though the headless core can advance ahead of them. The outcome is pending assessment.
+
+## Context
+
+The Bonsai editor has been a WinForms application since its inception. In 2011 WinForms was a mature, widely used UI toolkit with cross-platform reach through Mono, so the choice carried no platform cost. Since then Mono was superseded, and the research community that Bonsai serves increasingly works across Windows, macOS, and Linux. Although the editor was ported to build on .NET 8, the WinForms dependency became Windows-only under modern .NET, which means the editor cannot run cross-platform.
+
+The editor owns the entire operation model that manipulates a workflow: constructing, rewriting, and validating the underlying expression tree, managing selection and grouping, and persisting workflows and their layout. Much of this logic has no inherent dependence on WinForms, yet it is currently interleaved with the WinForms presentation.
+
+Two consequences follow. First, a move off WinForms is not a straight port of one UI framework to another; it first requires separating the operation model from the presentation, which is the subject of this record. Choosing the presentation stack that then sits over the operation model is a separate, reversible decision recorded in ADR-0004. Second, once the separation exists, the same operation model can be used with no presentation attached, which can serve as the basis for a headless editing surface for automation and agents. The editor and the headless player already enter through separate paths, `Launcher.LaunchWorkflowEditor` and `Launcher.LaunchWorkflowPlayer`, but both still depend on `Bonsai.Editor`, so headless editing is not yet a first-class surface.
+
+This axis is independent of the runtime-and-dependencies axis in ADR-0002 and can progress on its own timeline. The concrete per-project migrations of the standard library and community packages are out of scope here. ADR-0002 governs the timing, the track assignment, and the .NET Framework support window that any released cross-platform editor will inherit.
+
+## Operation Model
+
+The editor operation model is entangled with the presentation layer across many different axes. At the base is the graph-manipulation model: the explicit editing actions on a workflow, adding, removing, connecting, grouping, and rewriting nodes, with undo and redo support. This model is the heart of the presentation-independent library and is currently being refactored under the `Bonsai.Editor.GraphModel` namespace. It has progressed far enough to allow its logic to run under headless unit tests, even if its types have not yet been fully decoupled from WinForms.
+
+Layered over it is a large body of editor features that today mix editing logic with presentation, and their breadth is the real measure of the effort: docking and window management, the graph view with its rendering and interaction, layout, scripting, diagnostics, theming, the toolbox and the workflow explorer, find and replace, the runtime watch tool, documentation and export helpers, and SVG rendering of workflow icons, among others. Cataloging these features is part of the assessment, resolving the full scope of the migration, and marking for each feature what belongs to the operation-model library and what belongs to the presentation stack in ADR-0004.
+
+A minimal editor-agnostic library, seeded from the graph-manipulation model, can ship first as a new assembly and grow feature by feature as logic is lifted out of `Bonsai.Editor` and that project is progressively retracted. The migration can then proceed incrementally rather than as a single cut. Each step is strictly additive, keeping the existing WinForms editor working on top of the growing presentation-independent library.
+
+Beyond graph manipulation, two presentation-facing abstractions are the most consequential to get right, since operator and visualizer authors across the ecosystem depend on them. The first is the property model. Assigning property values is a core concern in its own right. Operator configuration relies on `System.ComponentModel`, the `TypeDescriptor` and `TypeConverter` services and the property attributes that let any operator be shown in a `PropertyGrid` and edited without bespoke UI. That metadata is part of the base class library and is portable, but the `PropertyGrid` control and the `UITypeEditor` model that extends it are bound to WinForms, so the operation model has to define a framework-neutral editor abstraction that each presentation stack is able to render. The second is the type visualizer model, built on the same pattern, where a visualizer receives an `IServiceProvider` through which it queries and manipulates the editor. The service infrastructure itself is already presentation-neutral, but some of the services it provides and the controls that visualizers create are currently WinForms-specific.
+
+## Assessments
+
+The operation model is assessed by a core decoupling prototype, a feature census, and two design questions it raises: programmatic property assignment over the headless surface, and the framework-neutral redesign of the presentation-facing extensibility contract. The core prototype becomes the implementation proposal in `bonsai-rx/bonsai`, while the census scopes the full migration and tracks its progress. Assessment reports are added under `assessments/` as each is finalized.
+
+| ID | Question | Method | Kind | Status | Exit Criterion |
+|----|----------|--------|------|--------|----------------|
+| A01 | Can the graph-manipulation operation model be decoupled from WinForms and run headlessly, validated by a headless consumer and a workflow-and-layout round-trip? | prototype | disqualifying | In Progress | A headless consumer requesting graph edits over the decoupled `GraphModel`, with a `.bonsai` load-edit-save round-trip that leaves existing files opening and editing unchanged |
+| A02 | What is the full inventory of `Bonsai.Editor` features, and for each, what belongs to the operation-model library versus the presentation stack in ADR-0004? | code-scan | survey | In Progress | A complete feature inventory of `Bonsai.Editor`, each entry marked operation-model, presentation, or split, maintained in this record as a scope-and-progress index |
+| A03 | How is an individual operator property assigned programmatically over the headless surface, without hand-manipulating XML fragments and namespaces, and where does string-based `TypeConverter` assignment stop, for example on read-only collection properties? | prototype | scoring | Open | A property-assignment API covering the common cases, with the reach and limits of string-based `TypeConverter` assignment characterized |
+| A04 | Can the presentation-facing extensibility contract be redesigned as framework-neutral, building on the `ComponentModel` property-editing model in place of `PropertyGrid` and `UITypeEditor`, and the `IServiceProvider` type visualizer model with its service and render abstractions? | prototype | scoring | Open | A framework-neutral design for both, rendered on a non-WinForms surface; may later split into separate property-editing and visualizer assessments, with the render surfaces possibly migrating to ADR-0004 |
+
+## Decision
+
+Pending the A01 prototype. The direction is to decouple the operation model from WinForms into a presentation-independent library. Since that core is independent of the presentation stack, once the prototype proves the decoupling it may be promoted to Approved and enter implementation on the ADR-0002 v2 track, ahead of the presentation stack decision in ADR-0004. Generalized property assignment and the framework-neutral property-editing and type visualizer abstractions are follow-on work over that core and may be deferred.
+
+## Consequences
+
+The headless editing surface the operation model unlocks is the natural home for the workflow conversion tooling that ADR-0002 relies on for forward-only migration. The `ComponentModel`-based property and editor model and the `IServiceProvider`-based visualizer model must be redesigned as framework-neutral abstractions the operation model owns. The operation model becomes the single owner of load and save, so workflow and layout compatibility is enforced in one place instead of inside the editor.
+
+The decoupling also opens two decisions that this record does not make, each to be scoped independently as its own record.
+
+- **Out-of-process execution**: running workflows in a separate process from the editor, in the manner of a debugger and its debuggee. There are three motivations supporting this: web editing and the plugin-host option in ADR-0004 both require exactly this process boundary; a workflow that runs inside the editor process will never be able to load a different version of a dependency required by the editor, and any unexpected crash can bring the whole editor down with it; and Dear ImGui is single-thread, with no upstream multithreading expected soon, so a standalone graphics or shader window that also uses it cannot currently run side-by-side.
+- **A Model Context Protocol server**: the decoupled operation model can be used with no presentation attached, which could allow agents to author and manipulate workflows programmatically over that headless surface. Because such a server would share the operation-model surface directly with the editor, it could be used as a critical test case of this decision.

--- a/decisions/0004-cross-platform-editor/README.md
+++ b/decisions/0004-cross-platform-editor/README.md
@@ -1,0 +1,106 @@
+---
+id: ADR-0004
+title: A cross-platform presentation stack for the Bonsai editor
+status: Assessment
+area: [Ecosystem, Infrastructure]
+authors: [glopesdev]
+related: [ADR-0002, ADR-0003]
+discussions:
+---
+
+# ADR-0004: A cross-platform presentation stack for the Bonsai editor
+
+## Summary
+
+Given the UI-agnostic operation model that ADR-0003 decouples from WinForms, this record decides which presentation stack the editor is rebuilt on to become cross-platform. Although ADR-0003 keeps the operation model largely independent of the presentation, the choice of stack is still critical, as rebuilding it is expensive, and operator and visualizer authors across the ecosystem depend on whatever the stack exposes, which is what has made the original WinForms choice so durable. The candidates are Avalonia, Uno, Dear ImGui, an existing code editor as a plugin host, and the WinForms-under-Wine baseline. The cutover to a non-WinForms stack is a breaking change held for the v3 batch. The outcome is pending assessment.
+
+## Context
+
+The editor is bound to Windows through WinForms. ADR-0003 decouples its operation model from WinForms so that the presentation can be replaced without changing it, and this record decides the replacement. The research community that Bonsai serves increasingly works across Windows, macOS, and Linux, while WinForms is Windows-only under modern .NET, so cross-platform reach is blocked by the UI framework rather than the runtime.
+
+Two elements apply regardless of the stack choice. The visualizer surface is the same surface used to render live data, and Dear ImGui is the near-certain choice for it regardless of which shell hosts the editor, since its immediate-mode model increasingly backs the visualizer work. Visualizer previews embedded in the editor are rendered through the same GPU pipeline as the 3D graphics stack, and both need a GL context and a function loader. Choosing them separately would put two of each in one process, so the presentation stack and the graphics backend have to be decided together.
+
+## Criteria
+
+The criteria in [criteria.md](../../criteria.md) that materially bear on this decision, with Cross-Platform Reach added for this decision.
+
+- Cross-Platform Reach, decision-specific: the extent to which the editor runs natively on Windows, macOS, and Linux without a compatibility layer. This is the primary motivation and is weighted highest.
+- Ecosystem Continuity Risk: existing workflows and their layout files must keep opening and editing as before.
+- Community Trust: a conservative user base judges the transition by whether existing work keeps running and by expanded reach for new users.
+- Maintenance Burden: the ongoing cost of tracking a UI stack and its platform backends.
+- Effort: reworking the editor is a large one-time cost against a bounded budget.
+- Reversibility: a later change of stack should not reach into the operation model or stored workflows. It does not make the presentation investment itself cheap to repeat.
+
+A trade-off matrix is framed below but left mostly to be resolved by assessment. At this stage the record draws the option space.
+
+## Options
+
+The operation model of ADR-0003 is common to every option and is not itself a choice here; the options are the presentation stack chosen over it. Options A, B, and C are native cross-platform toolkits; Option D hosts the editor inside an existing cross-platform code editor; Option E is the baseline. The choice between the two XAML options, A and B, turns on an open question, whether a browser or mobile editor is a committed goal within the v3 horizon. The presentation layer is costly enough to rebuild that the number of target stacks is itself a dominant factor, so a single cross-target codebase and a best-in-class desktop stack are competing goals. Option C answers the same multi-target cost a third way, one immediate-mode layer that runs wherever Dear ImGui runs.
+
+### Option A: Avalonia
+
+Build the presentation over Avalonia, a mature cross-platform XAML UI framework running natively on Windows, macOS, and Linux. Avalonia is proven at the scale of a full IDE through JetBrains Rider, and it has in-ecosystem precedent in the Harp device-configuration applications built on Avalonia 11 and .NET 8, so some contributor familiarity and a shared pattern already exist, even though those applications do not reuse editor infrastructure. On Windows, Avalonia can host a WinForms control through native HWND interop, which offers a transition bridge, so existing WinForms visualizers and property editors could keep running inside the Avalonia editor on Windows while their authors migrate. That bridge is Windows-only and subject to the usual native-embedding limits, so it eases the transition rather than extending those controls cross-platform. The open costs are the from-scratch rebuild of the workflow canvas and the `PropertyGrid` over the editor abstraction, and the XAML data-binding model, which is unfamiliar to the current WinForms-oriented contributors.
+
+### Option B: Uno Platform
+
+Build the presentation over Uno, a cross-platform framework that targets desktop, mobile, and WebAssembly from a single UI codebase, which would additionally open browser-hosted and mobile editors. Because the presentation layer is the expensive part of the rebuild for Bonsai, one codebase across every target is a real advantage over rebuilding the presentation once for desktop and again later for the web, and there is standing community interest in browser and mobile editors. Weighed against that, Uno has a less established desktop-native track record than Avalonia, its WebAssembly target cannot run hardware-bound workflows, so a browser editor is an authoring and monitoring surface rather than a full runtime, and it cannot host legacy WinForms controls, so it offers no Windows transition bridge. Uno uses the WinUI XAML dialect, so the unfamiliar data-binding model is shared with Avalonia.
+
+### Option C: Dear ImGui
+
+Build the shell itself in Dear ImGui, the immediate-mode toolkit already near-certain for the visualizer surface and already integrated in the ecosystem through `Bonsai.ImGui` over `Hexa.NET.ImGui`, so the editor, its visualizers, and the graphics backend share one rendering stack and one GL context. ImHex is an existence proof that an IDE-class interface, with docking, detachable windows, menus, inspector and property panels, theming, and custom fonts, is achievable in pure Dear ImGui, and it ships a WebAssembly build, so the paradigm reaches desktop and the web alike. The distinctive advantage is that the presentation layer is written once and runs on every target Dear ImGui reaches rather than once per stack, and the immediate-mode property and visualizer renderers sit directly on the framework-neutral abstractions the operation model owns. A standalone immediate-mode application has to manage retained editing state by hand, which here is already held in the operation model. The costs are a complete rewrite with no WinForms transition bridge, which is consistent with treating the .NET Framework build as the bridge, weaker accessibility and complex-text polish than a native or XAML stack, and a web target that runs .NET on WebAssembly hosting native Dear ImGui rather than the C++ and Emscripten path ImHex uses, which is less proven and must be verified.
+
+### Option D: Editor as a Plugin
+
+Rather than ship a standalone application shell, host the editing experience inside an existing cross-platform code editor such as VS Code or Zed, as an extension built on the operation model of ADR-0003. The appeal is real: VS Code is already the standard editor for Bonsai C# extensions, Bonsai projects are increasingly multi-language with configuration in Python and analysis in Python or MATLAB, and hosting the workflow editor there would place the whole project in one environment and inherit the cross-platform reach, window management, and extension ecosystem of the host. In practice the primary-editor story is weak. Language-server and other host protocols are text-oriented, so nothing standard assembles a visual editing layer, and the node canvas would be a webview built entirely from scratch, reusing less than any other option since it gains no rendering substrate, not even the structural guidance a Dear ImGui shell provides. It makes editor longevity depend on a third party and a fast-moving web substrate, adding the ongoing cost of tracking an extension API the project does not control, and it is not one target but a separate integration per host, since VS Code and Zed do not share an extension model. As a primary presentation stack it is therefore the weakest option, kept in the matrix for the history of why it was considered and for the downstream opportunities it seeds rather than as a likely winner.
+
+### Option E: Status Quo, WinForms Under Wine
+
+Keep the WinForms editor and reach non-Windows platforms through Wine, a cross-platform compatibility layer that reimplements the Windows API. Functional today and requiring no rework, but the editor is still not a native application on those platforms, as its behavior depends on Wine coverage of the specific Windows APIs the editor uses, and it does not resolve the underlying WinForms coupling. Scored as the baseline.
+
+## Trade-off Matrix
+
+Options as rows, criteria as columns. Cells that need measurement are framed as TBD against the assessment that will resolve them, and the rest are settled by reasoning here. No cell is filled by guesswork. Two must-pass checks sit outside the criteria columns: Ecosystem Continuity Risk, resolved by the decoupling prototype in ADR-0003, and complex-text support, resolved by A03.
+
+| Criterion | A: Avalonia | B: Uno | C: Dear ImGui | D: Plugin Host | E: Wine Baseline |
+|-----------|-------------|--------|---------------|----------------|------------------|
+| Cross-Platform Reach | TBD -> A01 | TBD -> A01 | TBD -> A01 | TBD -> A01 | not native, via a compatibility layer |
+| Ecosystem Continuity Risk | must-pass -> ADR-0003-A01 | must-pass -> ADR-0003-A01 | must-pass -> ADR-0003-A01 | must-pass -> ADR-0003-A01 | low, nothing changes |
+| Community Trust | TBD -> A02 | TBD -> A02 | TBD -> A02 | TBD -> A02 | erodes over time, reach stays non-native |
+| Maintenance Burden | TBD -> A02 | TBD -> A02 | TBD -> A02 | TBD -> A02 | medium, Wine upkeep |
+| Effort | TBD -> A01 | TBD -> A01 | TBD -> A01 | TBD -> A01 | none |
+| Reversibility | operation model insulated, WinForms bridge forfeited | operation model insulated | operation model insulated, shared GL stack also unpicked | not self-determined, the host can force a change | not applicable |
+
+## Assessments
+
+The decoupling prototype in ADR-0003-A01 is the shared foundation and is worked first, since it is what every option is built over. A03 is worked next, since a stack that cannot handle complex text is eliminated before any effort is spent prototyping it. A01 then compares the surviving stacks once the operation-model API exists, and A02 covers the two criteria a prototype cannot settle. Assessment reports are added under `assessments/` as each is finalized.
+
+| ID | Question | Method | Kind | Status | Exit Criterion |
+|----|----------|--------|------|--------|----------------|
+| A01 | How do the candidate presentation stacks compare on the hardest widgets, a `ComponentModel`-based `PropertyGrid` and a slice of the workflow canvas over the editor abstraction, plus cross-platform reach and the decisive per-stack risk, hosting a legacy WinForms control on Windows for Avalonia, and the .NET-on-WebAssembly path and the accessibility of an immediate-mode surface for Dear ImGui? | prototype | scoring | Open | A scoped prototype per surviving stack rebuilding the two hardest widgets over the editor abstraction, an effort estimate to parity, a note on platform coverage, and the per-stack risk check: WinForms hosting for Avalonia, and the .NET-on-WebAssembly Dear ImGui path plus a comparative account of accessibility support for Dear ImGui |
+| A02 | For each candidate stack, what is the ongoing cost of tracking it and its platform backends, and how is a move to it likely to be received by the existing user base and by prospective users on non-Windows platforms? | desk-research | scoring | Open | A per-stack account of release frequency, breaking-change history, platform backend count, and project governance, together with a read on community reception gathered from existing users and from prospective users currently blocked by the Windows-only editor |
+| A03 | Can each candidate stack display and accept complex text, including input through a platform input method editor and right-to-left scripts, in the workflow canvas and in property values? | prototype | disqualifying | Open | Text entry and display verified on each target platform for input method editor composition and for right-to-left scripts, in a node name and in a property value. A stack that cannot do this is eliminated before the A01 comparison |
+
+## Decision
+
+Pending assessment. The record stays in Assessment while the presentation stacks are prototyped over the ADR-0003 operation model.
+
+## Consequences
+
+Pending the full decision, a few commitments already bear on dependent work. The presentation stack and the graphics backend have to be decided together, since embedded visualizer previews and the 3D graphics stack share one GL context and loader in the editor process. If the presentation stack is Avalonia, existing WinForms controls can be hosted in the editor on Windows as a transition bridge, which is Windows-only and not a substitute for cross-platform reimplementation.
+
+Choosing between Options A and B needs a scope decision this record does not make: whether a browser or mobile editor is a committed goal within the v3 horizon. A single cross-target codebase is worth its cost only if that goal is committed, so the answer belongs to the v3 scope rather than here.
+
+Option D carries downstream opportunities that are a separate story from the primary stack choice, contingent on the outcome of this record and on the scope decision above.
+
+- **Remote and browser editing through a host**: hosting inside a code editor would inherit these, along with distribution, from the host largely for free.
+- **A shared web build**: a webview could host the web build of whichever stack is chosen for B or C, rather than a rendering layer of its own.
+- **Thin additive integrations over the operation model and the execution boundary**: a workflow preview renderer and a launch-and-debug integration over the Debug Adapter Protocol, alongside the future MCP surface.
+
+## References
+
+- Avalonia, at https://github.com/AvaloniaUI/Avalonia
+- Uno Platform, at https://github.com/unoplatform/uno
+- Dear ImGui, at https://github.com/ocornut/imgui
+- ImHex, an IDE-class application built entirely in Dear ImGui with a WebAssembly build, at https://github.com/WerWolv/ImHex
+- `Hexa.NET.ImGui`, the .NET bindings for Dear ImGui, at https://github.com/HexaEngine/Hexa.NET.ImGui
+- `Bonsai.ImGui`, the existing ecosystem Dear ImGui integration built over those bindings, at https://github.com/bonsai-rx/imgui


### PR DESCRIPTION
The cross-platform editor decision that ADR-0002 flagged opens here as two records rather than one, because its two halves have different reversibility and different timelines. Splitting them lets the foundational half progress and even be approved while the visible half is still being assessed.

ADR-0003 covers the foundational half, decoupling the editor operation model from WinForms into a presentation-independent library. It is additive, sits on the ADR-0002 v2 track, and can reach Approved ahead of any choice of UI framework, since nothing about it depends on which one is chosen. It is decided by reasoning rather than measurement, so it carries no options and no trade-off matrix. Its four assessments cover the decoupling prototype, a feature census of `Bonsai.Editor`, programmatic property assignment over the headless surface, and a framework-neutral redesign of the two extensibility abstractions that operator and visualizer authors depend on. The census uses the `survey` assessment kind defined in #26.

ADR-0004 covers the reversible half, which presentation stack the editor is rebuilt on. The options are Avalonia, Uno, Dear ImGui, an existing code editor as a plugin host, and the current WinForms-under-Wine baseline. Its trade-off matrix is deliberately mostly unfilled, with cells pointing at the assessments that will resolve them, and only the baseline column and the reversibility row settled by reasoning here. The cutover to a non-WinForms stack is a breaking change held for the v3 batch.

Both records open at Assessment, which is the intended state for a record created early. The repository register gains a row for each, and the ADR-0002 sub-decision bullet and `related` field now name them instead of announcing a record still to be created.

### What these records deliberately do not decide

ADR-0003 records two decisions the decoupling opens without settling them, out-of-process execution of workflows and a Model Context Protocol server over the headless surface. Both are expected to become their own records later.

ADR-0004 leaves the choice between the two XAML options resting on a scope question it cannot answer itself, whether a browser or mobile editor is a committed goal within the v3 horizon. A single cross-target codebase is worth its cost only if that goal is committed, so the answer belongs to the v3 scope rather than to this record.

### Review notes

The two extensibility abstractions in ADR-0003, the property model and the type visualizer model, are the part most worth scrutiny, since operator and visualizer authors across the ecosystem depend on them and a framework-neutral redesign is what the whole cross-platform editor rests on.

In ADR-0004, the Option D assessment of hosting inside an existing code editor concludes it is the weakest option as a primary stack, and it is kept in the matrix for the record of why it was considered and for the downstream opportunities it seeds. Pushback on that reading is welcome.
